### PR TITLE
Use the lighter blue color of theme Gruvbox

### DIFF
--- a/themes/gruvbox.css
+++ b/themes/gruvbox.css
@@ -45,7 +45,7 @@ body {
 }
 
 .highlight {
-  color: #458588;
+  color: #83a598;
 }
 
 .correct {


### PR DESCRIPTION
Great addition @rpbaptist! I love Gruvbox. It's my favorite for so many years.

I have one suggestion and that is to change the blue color of the highlight to the lighter variant in theme Gruvbox.

The lighter color 
```
.highlight {
  color: #83a598;
}
```